### PR TITLE
Add support to use a remote Ollama instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://github.com/taketwo/llm-ollama/actions/workflows/test.yml/badge.svg)](https://github.com/taketwo/llm-ollama/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/taketwo/llm-ollama/blob/main/LICENSE)
 
-[LLM](https://llm.datasette.io/) plugin providing access to models running on local [Ollama](https://ollama.ai) server.
+[LLM](https://llm.datasette.io/) plugin providing access to models running on a local or remote [Ollama](https://ollama.ai) server.
 
 ## Installation
 
@@ -43,6 +43,14 @@ Chatting with llama2:latest
 Type 'exit' or 'quit' to exit
 Type '!multi' to enter multiple lines, then '!end' to finish
 >
+```
+
+### Remote Ollama server
+
+If your Ollama server is remote ensure you define the `OLLAMA_HOST` environment variable so it is used instead of `localhost`.
+
+```bash
+export OLLAMA_HOST=https://192.168.1.13:11434
 ```
 
 ## Model aliases


### PR DESCRIPTION
Add support for `llm-ollama` to connect to a remote instance.

This uses the same environment variable that can be used with the standard `ollama` binary, `OLLAMA_HOST`